### PR TITLE
Add list filtering to provider interface and mega provider

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,19 +7,19 @@ import re
 
 async def main():
     driver = await Driver.get_instance()
-    provider = MegaProvider("")
+    provider = MegaProvider("/MEGAsync/TikTok")
     while True:
-        profiles = Profiles()
+        profiles = Profiles(False)
         for username, directory, recovery_id in profiles:
             result = await driver.get_profile(username)
             post_links = await result.get_post_links()
             pattern = re.compile(rf"https://www.tiktok.com/@{username}/(.*)/(\d*)")
             posts_info = [re.match(pattern, link).groups() for link in post_links]
-            filenames = [f"{directory} {post_id}.{"mp4" if post_type == "video" else "jpg"}" for (post_type, post_id) in posts_info]
-            
-            print(filenames)
+            posts_ids = [p[1] for p in posts_info]
             
             # Filter for posts that should be downloaded
+            posts_ids = provider.filter_list(directory, posts_ids)
+            posts_info = [p for p in posts_info if p[1] in posts_ids]
             
             # Download posts
             

--- a/modules/driver.py
+++ b/modules/driver.py
@@ -65,8 +65,8 @@ class Driver:
     async def __sign_in_as_guest(self, tab: Tab):
         while True:
             try:
-                button = await tab.select('div[class*=css-1gtmaw0-DivBoxContainer]', timeout=5)
-                await button.click()
+                buttons = await tab.select_all('div[class*=css-1cp64nz-DivTextContainer]', timeout=5)
+                await buttons[-1].click()
             except TimeoutError:
                 break
     

--- a/modules/profiles.py
+++ b/modules/profiles.py
@@ -3,7 +3,7 @@ import os
 import json
 
 class Profiles:
-    def __init__(self) -> None:
+    def __init__(self, use_state = True) -> None:
         os.makedirs(".state", exist_ok=True)
         if not os.path.exists(".state/state.json"):
             with open(".state/state.json", "w") as file:
@@ -14,7 +14,7 @@ class Profiles:
         with open(".state/state.json", "r+") as file:
             state = json.load(file)
         self.__profiles = list(csv.reader(open("profiles.csv", "r")))[1:]
-        self.__place = 0 if state["last"] >= len(self.__profiles) else state["last"]
+        self.__place = 0 if not use_state or state["last"] >= len(self.__profiles) else state["last"]
         
     def __iter__(self):
         if self.__place >= len(self.__profiles):

--- a/providers/mega.py
+++ b/providers/mega.py
@@ -1,6 +1,8 @@
 import requests
 import os
+from posixpath import join
 from .provider import Provider, Provision
+import re
 
 class MegaProvider(Provider):
     def __init__(self, mega_path) -> None:
@@ -10,9 +12,26 @@ class MegaProvider(Provider):
         return requests.get(
             url="http://localhost:15001/exists",
             params={
-                "path": os.path.join(self.__mega_path, directory, filename)
+                "path": join(self.__mega_path, directory, filename)
             }
             ).json()["result"]
+        
+    def filter_list(self, directory: str, post_ids: list[str]):
+        existing_filenames = requests.get(
+            url="http://localhost:15001/list_dir",
+            params={
+                "path": join(self.__mega_path, directory)
+            }
+        ).json()["result"]
+        pattern = re.compile(r"\d+")
+        matches = [
+            pattern.search(filename) for filename in existing_filenames
+        ]
+        matches = [
+            match.group(0) for match in matches if match
+        ]
+        matches = list(set(matches))
+        return [post_id for post_id in post_ids if post_id not in matches]
     
     def provision(self, directory: str, filename: str) -> Provision:
         os.makedirs("tmp", exist_ok=True)
@@ -21,7 +40,7 @@ class MegaProvider(Provider):
             requests.put(
                 url="http://localhost:15001/upload",
                 data={
-                    "path": os.path.join(self.__mega_path, directory, filename)
+                    "path": join(self.__mega_path, directory, filename)
                 },
                 files={
                     "file": open(f"tmp/{filename}", "rb")

--- a/providers/provider.py
+++ b/providers/provider.py
@@ -7,7 +7,10 @@ class Provider:
     '''
         A provider should create a file which will be written to by the download handler, and should handle the events that follow the completion of the file.
     '''
-    def should_upload(directory: str, post_id: str, extension: str) -> bool:
+    def should_upload(self, directory: str, post_id: str, extension: str) -> bool:
+        raise NotImplementedError()
+    
+    def filter_list(self, directory: str, post_ids: list[str]):
         raise NotImplementedError()
     
     def provision(self, directory: str, filename: str) -> Provision:


### PR DESCRIPTION
Instead of making a call to the MEGA server for every file, we can make a single call per directory instead.

The real reason for this is that we have to use list_dir to filter for posts to download as photos and videos follow different naming schemes.